### PR TITLE
Google Analytics 埋め込み (kobake アカウント)

### DIFF
--- a/download.html
+++ b/download.html
@@ -4,7 +4,16 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="Content-Style-Type" content="text/css">
 
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'UA-120820034-1');
+  </script>
 
   <link href="./dsk_sakura.css" type="text/css" rel="stylesheet">
   <link rel="shortcut icon" href="favicon.ico">

--- a/index.en.html
+++ b/index.en.html
@@ -6,6 +6,16 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="Content-Language" content="en-us">
   <meta http-equiv="Content-Style-Type" content="text/css">
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'UA-120820034-1');
+  </script>
+
   <meta name="description" content="Sakura Editor is a free Japanese editor for MS-Windows">
   <meta name="keywords" content="Text Editor,Free,Japanese">
   <link href="./dsk_sakura.css" type="text/css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,16 @@
   <meta charset="utf-8">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="Content-Style-Type" content="text/css">
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'UA-120820034-1');
+  </script>
+
   <meta name="description" content="サクラエディタはMS-Windows上で動作するフリーの日本語テキストエディタです">
   <meta name="keywords" content="エディタ,テキストエディタ,フリーウェア,プログラミング">
   <link href="./dsk_sakura.css" type="text/css" rel="stylesheet">

--- a/intro.html
+++ b/intro.html
@@ -5,6 +5,16 @@
   <meta charset="utf-8">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="Content-Style-Type" content="text/css">
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+    gtag('config', 'UA-120820034-1');
+  </script>
+
   <meta name="description" content="サクラエディタの紹介ページです。" lang="ja">
   <meta name="keywords" content="エディタ,テキストエディタ,サクラエディタ" lang="ja">
   <link href="./dsk_sakura.css" type="text/css" rel="stylesheet">


### PR DESCRIPTION
現存の全ての html に Google Analytics コードを読み込み。
共有アカウントで設定することも考えたが、#14 にも書いたとおり、複数人で運用する場合はその人数分のタグを別個に埋め込むのが一般的らしい。

以下、Google Analytics での案内文。

## ウェブサイトのトラッキング
### グローバル サイトタグ（gtag.js）
このプロパティで使用できる Global Site Tag（gtag.js）トラッキング コードです。このコードをコピーして、トラッキングするすべてのウェブページの <HEAD> 内の最初の要素として貼り付けてください。ページにすでに Global Site Tag が配置されている場合は、以下のスニペットの config 行のみを既存の Global Site Tag に追加してください。

```
<!-- Global site tag (gtag.js) - Google Analytics -->
<script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', 'UA-120820034-1');
</script>
```

Global Site Tag（gtag.js）を使用すると、Google のサイトの測定、コンバージョン トラッキング、リマーケティング サービスでのタグ設定が合理化されます。タグの管理や実装も容易になります。また、公開される最新の動的な機能や統合のメリットをすぐに活かすことができます。
