### PR TITLE
古い Google Analytics コードを削除

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -291,13 +291,6 @@
   <p>
     <a href="#top">▲戻る</a>
   </p>
-
-  <script type="text/javascript">
-    _uacct = "UA-2071300-1";
-    urchinTracker();
-  </script>
-  <script src="//www.google-analytics.com/urchin.js" type="text/javascript">
-  </script>
 </body>
 
 </html>


### PR DESCRIPTION
SourceForge 時代の HTML に残っていた Google Analytics のコードとして `UA-2071300-1` が残っていましたが、以下理由により該当コードを削除します。

- 所有者不明（諸々検索してみたけど情報見つからず）
- このコードにより `Uncaught ReferenceError: urchinTracker is not defined` のエラーが発生する
- そもそも urchin.js のサポートは切れている (ファイルは残っている模様ですが)
