### PR TITLE
ドメイン外サイト情報を sitemap から削除

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,40 +18,4 @@
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
 </url>
-<url>
-    <loc>https://github.com/sakura-editor/sakura/issues</loc>
-    <lastmod>2018-06-06</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.5</priority>
-</url>
-<url>
-    <loc>https://github.com/sakura-editor/sakura/pulls</loc>
-    <lastmod>2018-06-06</lastmod>
-    <changefreq>daily</changefreq>
-    <priority>0.5</priority>
-</url>
-<url>
-    <loc>https://osdn.net/projects/sakura-editor/forums/</loc>
-    <lastmod>2018-06-06</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.4</priority>
-</url>
-<url>
-    <loc>http://sakura-editor.sourceforge.net/htmlhelp/</loc>
-    <lastmod>2013-03-31</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-</url>
-<url>
-    <loc>http://sakura-editor.sourceforge.net/doxygen2/</loc>
-    <lastmod>2017-05-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-</url>
-<url>
-    <loc>http://sakura-editor.sourceforge.net/doxygen/</loc>
-    <lastmod>2017-05-02</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.4</priority>
-</url>
 </urlset>


### PR DESCRIPTION
Google Webmasters の画面で気づいたのですが、別ドメインのサイト情報が sitemap.xml に書かれているとエラーになるようでした。ので、別ドメインのサイト情報は sitemap.xml から削除します。

<img width="683" alt="sitemap" src="https://user-images.githubusercontent.com/2929454/41331733-7b36b412-6f15-11e8-8640-481d8c742d11.png">

