### PR TITLE
Slack リンクを Discord リンクに差し替え

### DIFF
--- a/index.en.html
+++ b/index.en.html
@@ -91,7 +91,7 @@
   <ul>
     <li><a href="https://github.com/sakura-editor/sakura/issues"  target="_blank">GitHub Issues</a></li>
     <li><a href="https://github.com/sakura-editor/sakura/pulls"   target="_blank">GitHub Pull requests</a></li>
-    <li><a href="https://sakura-editor-slack.herokuapp.com/"      target="_blank">Slack</a></li>
+    <li><a href="https://discord.gg/MTWB4ut"                      target="_blank">Discord</a> ... Chat room.</li>
     <li><a href="http://sakura.qp.land.to"                        target="_blank">land.to Wiki</a> ... FAQ, Tips, Document, etc.</li>
   </ul>
   

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@
   <ul>
       <li><a href="https://github.com/sakura-editor/sakura/issues" target="_blank">GitHub Issues</a> … 要望・バグ報告等</li>
       <li><a href="https://github.com/sakura-editor/sakura/pulls"  target="_blank">GitHub Pull requests</a> … ソースコード変更リクエスト</li>
-      <li><a href="https://sakura-editor-slack.herokuapp.com/"     target="_blank">Slack</a> … 一般話題・開発話題 混在チャット</li>
+      <li><a href="https://discord.gg/MTWB4ut"                     target="_blank">Discord</a> … 一般話題・開発話題 混在チャット</li>
       <li><a href="http://sakura.qp.land.to"                       target="_blank">land.to Wiki</a> … FAQ, Tips, Document, etc.</li>
     <li><a href="https://osdn.net/projects/sakura-editor/forums/"  target="_blank">OSDNフォーラム</a> … 匿名投稿可能な掲示板</li>
     <li style="margin-top:10px; color: #666; font-size: small;">旧掲示板（折を見て閉鎖予定。ログ検索機能は残します。）


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/issues/143 で提案していた内容に基づくものです。
チャットツールを Slack から Discord 運用に切り替えるため、Web サイトからのリンクも差し替えます。

Discord のリンク https://discord.gg/MTWB4ut は @kobake が生成した招待リンクです。
招待リンクは誰でも生成できますが、生成者によって URL は変わります。

本当は https://discord.gg/sakura-editor みたいな分かりやすい名前のリンクが作れたら良かったのですが。一応 [Discord Partners](https://discordapp.com/partners) と認められれば [良い感じの URL 作れるみたい](https://feedback.discordapp.com/forums/326712-discord-dream-land/suggestions/10313148-custom-url-names) ですが、Discord Partners の条件がいろいろめんどくさい感じなので、今回は普通の招待リンクで取り回そうと思います。
