### PR TITLE
トップページ右上に GitHub ribbon を設置

### DIFF
--- a/index.en.html
+++ b/index.en.html
@@ -24,6 +24,12 @@
 </head>
 
 <body>
+  <!-- GitHub ribbon on the upper right corner -->
+  <a href="https://github.com/sakura-editor/sakura" target="_blank">
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"
+      alt="Fork me on GitHub">
+  </a>
+
   <h1 class="title"> Text Editor "SAKURA"</h1>
   <p>
     <b>"SAKURA"</b> is a Japanese text editor for MS Windows.</p>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,12 @@
 </head>
 
 <body>
+  <!-- GitHub ribbon on the upper right corner -->
+  <a href="https://github.com/sakura-editor/sakura" target="_blank">
+    <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"
+      alt="Fork me on GitHub">
+  </a>
+
   <p>
     [▲HOME]
     [<a href="/intro.html">機能紹介</a>]


### PR DESCRIPTION
#27 の対応。

トップページ右上に GitHub ribbon を表示させることで、「サクラエディタは GitHub 上で開発されている」ことに気づいてもらいやすくしたい。（左上だと上部ナビゲーションに被るので右上にしました）

以下でサンプルを見れます。
https://kobake.github.io/sakura-editor.github.io/

## スクリーンショット
### PC 版
![](https://user-images.githubusercontent.com/2929454/42207425-d83e0db6-7ee4-11e8-9e63-a1192ee7cafa.png)

### スマホ版
（もともとのページ構成がそれほどスマホ意識して作られていない（と思っています）ですが、一応スマホ表示でもリボンが邪魔になっていないことを確認）

![](https://user-images.githubusercontent.com/2929454/42207428-d91fcb48-7ee4-11e8-800b-3982bc944555.png)

## 参考資料
以下で提示されている HTML を参考にしてます。

https://blog.github.com/2008-12-19-github-ribbons/
