### PR TITLE
Google Analytics コードの埋め込みを一元管理できるようにする

### DIFF
--- a/download.html
+++ b/download.html
@@ -6,8 +6,9 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="Content-Style-Type" content="text/css">
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+<!-- Start Google Analytics -->
+<script async type="text/javascript" src="googleanalytics.js"></script>
+<!-- End Google Analytics -->
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }

--- a/googleanalytics.js
+++ b/googleanalytics.js
@@ -1,0 +1,8 @@
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+// Google Analytics tracking code for kobake
+ga('create', 'UA-120820034-1', 'auto');
+ga('send', 'pageview');

--- a/googleanalytics.js
+++ b/googleanalytics.js
@@ -6,3 +6,7 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 // Google Analytics tracking code for kobake
 ga('create', 'UA-120820034-1', 'auto');
 ga('send', 'pageview');
+
+// Google Analytics tracking code for m-tmatma
+ga('create', 'UA-49508988-2', 'auto');
+ga('send', 'pageview');

--- a/index.en.html
+++ b/index.en.html
@@ -7,8 +7,9 @@
   <meta http-equiv="Content-Language" content="en-us">
   <meta http-equiv="Content-Style-Type" content="text/css">
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+<!-- Start Google Analytics -->
+<script async type="text/javascript" src="googleanalytics.js"></script>
+<!-- End Google Analytics -->
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }

--- a/index.html
+++ b/index.html
@@ -6,8 +6,9 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="Content-Style-Type" content="text/css">
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+<!-- Start Google Analytics -->
+<script async type="text/javascript" src="googleanalytics.js"></script>
+<!-- End Google Analytics -->
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }

--- a/intro.html
+++ b/intro.html
@@ -6,8 +6,9 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta http-equiv="Content-Style-Type" content="text/css">
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+<!-- Start Google Analytics -->
+<script async type="text/javascript" src="googleanalytics.js"></script>
+<!-- End Google Analytics -->
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }

--- a/update-google-analytics.py
+++ b/update-google-analytics.py
@@ -17,7 +17,7 @@ import re
 # <script type="text/javascript" src="/hoge/huga/hoge.js"></script>
 def replace_js_file(path, out_path, js_file):
 	data = '''<!-- Start Google Analytics -->
-<script type="text/javascript" src="{filename}"></script>
+<script async type="text/javascript" src="{filename}"></script>
 <!-- End Google Analytics -->
 '''.format(filename=js_file)
 

--- a/update-google-analytics.py
+++ b/update-google-analytics.py
@@ -1,0 +1,51 @@
+﻿#!/usr/bin/python
+
+import os
+import codecs
+import string
+import re
+
+#  <!-- Global site tag (gtag.js) - Google Analytics -->
+#  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-120820034-1"></script>
+#  <script>
+#    window.dataLayer = window.dataLayer || [];
+#    function gtag() { dataLayer.push(arguments); }
+#    gtag('js', new Date());
+#    gtag('config', 'UA-120820034-1'); // kobake 所有の Google Analytics tracking code
+#  </script>
+
+# <script type="text/javascript" src="/hoge/huga/hoge.js"></script>
+def replace_js_file(path, out_path, js_file):
+	data = '''<!-- Start Google Analytics -->
+<script type="text/javascript" src="{filename}"></script>
+<!-- End Google Analytics -->
+'''.format(filename=js_file)
+
+	with codecs.open(out_path, 'w', 'utf-8') as f_out:
+		startTag = False
+	
+		with codecs.open(path, 'r', 'utf-8') as f_in:
+			for line in f_in:
+				if re.search('Google Analytics', line) and re.search('<!--', line):
+					startTag = True
+				elif startTag and re.search('</script>', line):
+					startTag = False
+					f_out.write(data)
+				elif not startTag:
+					f_out.write(line)
+
+js_file = os.path.abspath('googleanalytics.js')
+scriptdir = os.path.dirname(os.path.realpath(__file__))
+for dirpath, dirnames, filenames in os.walk(scriptdir):
+	for file in filenames:
+		if file.endswith('.html'):
+			js_relative_path = os.path.relpath(js_file, dirpath)
+			js_relative_path = js_relative_path.replace('\\', '/')
+			path = os.path.join(dirpath, file)
+			
+			out_path = path + ".tmp"
+			replace_js_file(path, out_path, js_relative_path)
+
+			print (js_relative_path, path)
+			os.remove(path)
+			os.rename(out_path, path)


### PR DESCRIPTION
#30: Google Analytics コードの埋め込みを一元管理できるようにする

- [Google Analyticsのトラッキングコードを外部ファイルで読み込む](https://teratail.com/questions/122912)
- [サイトに analytics.js を追加する ](https://developers.google.com/analytics/devguides/collection/analyticsjs/?hl=ja)
- [アナリティクスのタグを複数設置する正しいやり方](http://primarytext.jp/blog/1412)

※ この PR の後に @m-tmatma の Google Analytics コードも足してみようと思います。
※ HTML ファイル更新用の python はコメントとか手を抜いています。必要なら足します。




