### PR TITLE
OSDN未ログイン時にGitHubページからOSDNフォーラム遷移時に英語表示になるのを修正。

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         [<a href="/intro.html">機能紹介</a>]
         [<a href="/download.html">ダウンロード</a>]
         [<a href="https://github.com/sakura-editor/sakura/issues" target="_blank">GitHub Issues</a>]
-        [<a href="https://osdn.net/projects/sakura-editor/forums/" target="_blank">OSDNフォーラム</a>]
+        [<a href="https://ja.osdn.net/projects/sakura-editor/forums/" target="_blank">OSDNフォーラム</a>]
         [<a href="index.en.html" target="_blank">English</a>]
     </p>
     <h1 class="title">サクラエディタ</h1>

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
                 <li><a href="https://github.com/sakura-editor/sakura/pulls" target="_blank">GitHub Pull requests</a> … ソースコード変更リクエスト</li>
                 <li><a href="https://discord.gg/MTWB4ut" target="_blank">Discord</a> … 一般話題・開発話題 混在チャット</li>
                 <li><a href="http://sakura.qp.land.to" target="_blank">land.to Wiki</a> … FAQ, Tips, Document, etc.</li>
-                <li><a href="https://osdn.net/projects/sakura-editor/forums/" target="_blank">OSDNフォーラム</a> … 要望・質問等GitHub投稿が難しい方はこちらをご利用ください (匿名投稿も可)</li>
+                <li><a href="https://ja.osdn.net/projects/sakura-editor/forums/" target="_blank">OSDNフォーラム</a> … 要望・質問等GitHub投稿が難しい方はこちらをご利用ください (匿名投稿も可)</li>
             </ul>
             <h2>過去ログ</h2>
             <form style="margin-left:1em" action="https://www.google.com/search" id="bbslog-search-box">


### PR DESCRIPTION
https://sakura-editor.github.io/ より、OSDNフォーラム遷移時に、
https://osdn.net/projects/sakura-editor/forums/
だと英語表記になるため、以下、
https://ja.osdn.net/projects/sakura-editor/forums/
に修正。