### PR TITLE
Ver2.4.0リリースに伴いトップページ修正

### DIFF
--- a/index.en.html
+++ b/index.en.html
@@ -28,8 +28,8 @@
   <h1 class="title"> Text Editor "SAKURA"</h1>
   <p>
     <b>"SAKURA"</b> is a Japanese text editor for MS Windows.</p>
-    <b>Before Ver. 2.3.2.0</b> MS Windows 2000/XP/Vista/7/8/10 is required.
-    <b>After Ver. 2.4.0.0</b> MS Windows10 is required.
+    <b>Till Ver. 2.3.2.0</b> MS Windows 2000/XP/Vista/7/8/10 is required.
+    <b>From Ver. 2.4.0.0</b> MS Windows10 is required.
     <br> English User Interface is supported since 2.1.1.1</p>
 
   <p class="note">Most pages linked below are written in Japanese. A Japanese font should be installed on your PC to enjoy them.</p>

--- a/index.en.html
+++ b/index.en.html
@@ -28,17 +28,15 @@
   <h1 class="title"> Text Editor "SAKURA"</h1>
   <p>
     <b>"SAKURA"</b> is a Japanese text editor for MS Windows.</p>
-  <p>
-    <b>Ver. 1.x.x.x(ANSI version)</b> Japanese MS Windows 95/98/NT/2000/XP/Vista/7/8/10 is required.
-    <br> Most double-byte characters are not shown properly on other language versions of MS Windows.</p>
-  <p>
-    <b>Ver. 2.x.x.x(Unicode version)</b> MS Windows 2000/XP/Vista/7/8/10 is required.
+    <b>Before Ver. 2.3.2.0</b> MS Windows 2000/XP/Vista/7/8/10 is required.
+    <b>After Ver. 2.4.0.0</b> MS Windows10 is required.
     <br> English User Interface is supported since 2.1.1.1</p>
 
   <p class="note">Most pages linked below are written in Japanese. A Japanese font should be installed on your PC to enjoy them.</p>
 
   <h2>What's New</h2>
   <ul>
+    <li>2020-01-26 release Ver.2.4.0 (Executable and Installer)</li>
     <li>2018-06-02 add link to <a href="https://github.com/sakura-editor/sakura/wiki" target="_blank">GitHub Wiki</a> </li>
     <li>2018-05-28 The project of "SAKURA" has migrated from SourceForge to <a href="https://github.com/sakura-editor/sakura" target="_blank">GitHub<a></li>
     <li>2017-05-02 Ver.2.3.2.0 (Unicode Version) (Executable)</li>
@@ -48,6 +46,11 @@
 
   <h2>Download</h2>
   <dl>
+    <dt><a href="https://github.com/sakura-editor/sakura/releases" target="_blank">GitHub Releases</a> (Now)</dt>
+    <dd>
+      <span style="color: #080; font-weight: bold;">Notice: In the future, this GitHub space will be mainly maintained.</span>
+    </dd>
+
     <dt><a href="http://sourceforge.net/projects/sakura-editor/files/" target="_blank">SourceForge files</a> (Old)</dt>
     <dd>
       Released package files as well as sources/binaries/help files.
@@ -55,19 +58,20 @@
       <span style="color: #f00; font-weight: bold;">Notice: this SourceForge space is obsoleted. See GitHub below.</span>
     </dd>
     
-    <dt><a href="https://github.com/sakura-editor/sakura/releases" target="_blank">GitHub Releases</a> (New)</dt>
-    <dd>
-      <span style="color: #080; font-weight: bold;">Notice: In the future, this GitHub space will be mainly maintained.</span>
-    </dd>
     
-    <dt>Auto download tool</dt>
-    <dd>
-      <a href="http://sakura.qp.land.to/?Install%2FSakuraDown" target="_blank">SakuraDown</a> automate download and installation process of sakura editor and related files.
-    </dd>
   </dl>
 
   <h2>Development</h2>
   <dl>
+    
+    <dt><a href="https://github.com/sakura-editor" target="_blank">GitHub Organization</a> (Now)</dt>
+    <dd>
+      <ul>
+        <li><a href="https://github.com/sakura-editor/sakura" target="_blank">SAKURA repository</a>
+        <li><a href="https://github.com/sakura-editor/sakura/wiki" target="_blank">GitHub Wiki</a> (for developers)</li>
+      </ul>
+      <span style="color: #080; font-weight: bold;">Notice: In the future, this GitHub space will be mainly maintained.</span>
+    </dd>
     <dt><a href="http://sourceforge.net/projects/sakura-editor/" target="_blank">SourceForge project</a> (Old)</dt>
     <dd>
       <ul>
@@ -77,15 +81,7 @@
       </ul>
       <span style="color: #f00; font-weight: bold;">Notice: this SourceForge space is obsoleted. See GitHub below.</span>
     </dd>
-    
-    <dt><a href="https://github.com/sakura-editor" target="_blank">GitHub Organization</a> (New)</dt>
-    <dd>
-      <ul>
-        <li><a href="https://github.com/sakura-editor/sakura" target="_blank">SAKURA repository</a>
-        <li><a href="https://github.com/sakura-editor/sakura/wiki" target="_blank">GitHub Wiki</a> (for developers)</li>
-      </ul>
-      <span style="color: #080; font-weight: bold;">Notice: In the future, this GitHub space will be mainly maintained.</span>
-    </dd>
+
   </dl>
   
   <h2>Discussions &amp; Documents</h2>

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
                         <li><a href="http://svn.code.sf.net/p/sakura-editor/code/sakura/trunk2" target="_blank">サクラエディタ本体 V2 (Unicode版) 最新ソースコード (trunk2)</a></li>
                         <li><a href="http://svn.code.sf.net/p/sakura-editor/code/sakura/trunk" target="_blank">サクラエディタ本体 V1 (ANSI版) 最新ソースコード (trunk)</a></li>
                     </ul>
-                    <span style="color: red; font-weight: bold;">※利便性・安定性の観点から、SourceForge は運用を停止し、 GitHub に運用を移転しました。</span>
+                    <span style="color: red; font-weight: bold;">※利便性・安定性の観点から、SourceForge における運用を停止し GitHub に移転しました。/span>
                 </dd>
 
             </dl>

--- a/index.html
+++ b/index.html
@@ -60,13 +60,14 @@
 
     <h2>概要</h2>
     <p>サクラエディタはMS Windows上で動作する日本語テキストエディタです。</p>
-    <p>Ver. 2.x.x.x(Unicode版) ではMS Windows 10が必要です。</p>
+    <p>Ver. 2.3.2.0 以前のバージョンは MS Windows 2000/XP/Vista/7/8/10 で動作します。</p>
+    <p>Ver. 2.4.0.0 以降のバージョンは MS Windows 10 で動作します。</p>
 
     <a href="intro.html">サクラエディタの機能紹介（スクリーンショット等）</a>
 
     <h2>What's New</h2>
     <ul>
-        <li>2020-01-26　Ver.2.4.0 (Unicode版) をリリースしました。</li>
+        <li>2020-01-26　Ver.2.4.0 をリリースしました。</li>
         <li>2018-06-02　<a href="https://github.com/sakura-editor/sakura/wiki" target="_blank">GitHub Wiki</a> へのリンクを追加</li>
         <li>2018-05-28　プロジェクトを SourceForge から <a href="https://github.com/sakura-editor/sakura" target="_blank">GitHub</a> に移転しました。</li>
         <li>2017-05-02　Ver.2.3.2.0 (Unicode版) 単体配布版をリリースしました。</li>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         <!-- 見出しと検索ボックスを同じ行にいれるために form タグの中に入れています -->
         [▲HOME]
         [<a href="/intro.html">機能紹介</a>]
-        [<a href="/download.html">ダウンロード</a>]
+        [<a href="https://github.com/sakura-editor/sakura/releases">ダウンロード</a>]
         [<a href="https://github.com/sakura-editor/sakura/issues" target="_blank">GitHub Issues</a>]
         [<a href="https://ja.osdn.net/projects/sakura-editor/forums/34071/" target="_blank">一般話題（質疑・要望等）</a>]
         [<a href="https://ja.osdn.net/projects/sakura-editor/forums/34094/" target="_blank">マクロ掲示板</a>]
@@ -60,13 +60,13 @@
 
     <h2>概要</h2>
     <p>サクラエディタはMS Windows上で動作する日本語テキストエディタです。</p>
-    <p>Ver. 1.x.x.x(ANSI版) ではMS Windows (95)98/NT/2000/XP/Vista/7/8/10の日本語版が必要です。</p>
-    <p>Ver. 2.x.x.x(Unicode版) ではMS Windows 2000/XP/Vista/7/8/10が必要です。</p>
+    <p>Ver. 2.x.x.x(Unicode版) ではMS Windows 10が必要です。</p>
 
     <a href="intro.html">サクラエディタの機能紹介（スクリーンショット等）</a>
 
     <h2>What's New</h2>
     <ul>
+        <li>2020-01-26　Ver.2.4.0 (Unicode版) をリリースしました。</li>
         <li>2018-06-02　<a href="https://github.com/sakura-editor/sakura/wiki" target="_blank">GitHub Wiki</a> へのリンクを追加</li>
         <li>2018-05-28　プロジェクトを SourceForge から <a href="https://github.com/sakura-editor/sakura" target="_blank">GitHub</a> に移転しました。</li>
         <li>2017-05-02　Ver.2.3.2.0 (Unicode版) 単体配布版をリリースしました。</li>
@@ -74,56 +74,39 @@
         <li>2013-03-31　Ver.1.6.7.0 (ANSI版) 単体配布版をリリースしました。</li>
     </ul>
   
-  <h2>簡易ダウンロード</h2>
+  <h2>ダウンロード</h2>
   <dl>
     <dt>
-      <a href="./download.html">インストーラパッケージダウンロード</a>
+      <a href="https://github.com/sakura-editor/sakura/releases">インストーラ、パッケージダウンロード</a>
             </dt>
-            <dd>本体、ヘルプ、関連ファイルを1ファイルにまとめたインストーラ。インストール後に最新実行ファイルで上書きしても正しく動作します。
+            <dd>本体、ヘルプ、関連ファイルを1ファイルにまとめたインストーラおよび実行ファイルのzip圧縮ファイル。インストール後に最新実行ファイルで上書きしても正しく動作します。
             </dd>
 
-            <dt>最新バイナリ＋関連ファイル簡単GET</dt>
-            <dd>
-                <a href="http://sakura.qp.land.to/?Install%2FSakuraDown" target="_blank">SakuraDown</a>で、各種関連ファイルを自動的に取得できます。
-            </dd>
-            </dl>
+  </dl>
 
-            <h2>詳細ダウンロード</h2>
+            <h2>旧版ダウンロード</h2>
             <dl>
-                <dt><a href="https://sourceforge.net/projects/sakura-editor/files/" target="_blank">SourceForge Sakura Editor Files</a> [英語] (Old)</dt>
+                <dt><a href="./download.html" target="_blank">SourceForge Sakura Editor Files</a> [英語] (Old)</dt>
                 <dd>
-                    最新のリリースソース/ヘルプファイル/実行ファイルがここからダウンロードできます。 helpとあるのがヘルプファイル、sakura,sakura2とあるのがエディタ本体(V1,V2)で、拡張子が.zipのものが実行形式、.tar.gz/.bz2のものがソースファイルです。
-                    <br/>
-                    <br/>
-                    <span style="color: red; font-weight: bold;">※利便性・安定性の観点から、本 SourceForge は運用を停止し、後述の GitHub に運用を移転します。</span>
+                    GitHub移転前に公開されていたバージョンのダウンロード方法等記載。
                 </dd>
 
-                <dt><a href="https://github.com/sakura-editor/sakura/releases" target="_blank">GitHub Sakura Editor Releases</a> [英語] (New)</dt>
+                <dt>バイナリ＋関連ファイル簡単GET</dt>
                 <dd>
-                    現在、SourceForge からこちらの GitHub へ移転作業の実施中です。今後はこちらから最新バイナリをダウンロードできるようになります。
+                    <a href="http://sakura.qp.land.to/?Install%2FSakuraDown" target="_blank">SakuraDown</a>で、各種関連ファイルを自動的に取得できます。
                 </dd>
-
+    
                 <dt>64bit版バイナリ</dt>
                 <dd>
-                    64bit版バイナリはこちら
+                    旧版の64bit版バイナリはこちら
                     <a href="http://sourceforge.net/p/sakura-editor/wiki/64bit/" target="_blank">Unicode</a> /
-                    <a href="http://www.geocities.jp/moca_skr/old/bin_64bit.html" target="_blank">ANSI</a>です。(最新版ではありません。)
+                    <s><a href="." target="_blank">ANSI</a>版の公開サイトは閉鎖されました。</s>
                 </dd>
             </dl>
 
             <h2>開発</h2>
             <dl>
-                <dt><a href="http://sourceforge.net/projects/sakura-editor/" target="_blank">SourceForge Sakura Editor Project</a> (Old)</dt>
-                <dd>
-                    <ul>
-                        <li><a href="http://sourceforge.net/p/sakura-editor/code/" target="_blank">全ソースコード</a></li>
-                        <li><a href="http://svn.code.sf.net/p/sakura-editor/code/sakura/trunk2" target="_blank">サクラエディタ本体 V2 (Unicode版) 最新ソースコード (trunk2)</a></li>
-                        <li><a href="http://svn.code.sf.net/p/sakura-editor/code/sakura/trunk" target="_blank">サクラエディタ本体 V1 (ANSI版) 最新ソースコード (trunk)</a></li>
-                    </ul>
-                    <span style="color: red; font-weight: bold;">※利便性・安定性の観点から、本 SourceForge は運用を停止し、後述の GitHub に運用を移転します。</span>
-                </dd>
-
-                <dt><a href="https://github.com/sakura-editor" target="_blank">GitHub Sakura Editor Organization</a> (New)</dt>
+                <dt><a href="https://github.com/sakura-editor" target="_blank">GitHub Sakura Editor Organization</a> (Now)</dt>
                 <dd>
                     <ul>
                         <li><a href="https://github.com/sakura-editor/sakura" target="_blank">サクラエディタ本体リポジトリ</a></li>
@@ -131,6 +114,16 @@
                     </ul>
                     <span style="color: #080; font-weight: bold;">※SourceForge を引継ぐ形で、今後は本 GitHub を開発リポジトリとして運用していきます。</span>
                 </dd>
+                <dt><a href="http://sourceforge.net/projects/sakura-editor/" target="_blank">SourceForge Sakura Editor Project</a> (Old)</dt>
+                <dd>
+                    <ul>
+                        <li><a href="http://sourceforge.net/p/sakura-editor/code/" target="_blank">全ソースコード</a></li>
+                        <li><a href="http://svn.code.sf.net/p/sakura-editor/code/sakura/trunk2" target="_blank">サクラエディタ本体 V2 (Unicode版) 最新ソースコード (trunk2)</a></li>
+                        <li><a href="http://svn.code.sf.net/p/sakura-editor/code/sakura/trunk" target="_blank">サクラエディタ本体 V1 (ANSI版) 最新ソースコード (trunk)</a></li>
+                    </ul>
+                    <span style="color: red; font-weight: bold;">※利便性・安定性の観点から、SourceForge は運用を停止し、 GitHub に運用を移転しました。</span>
+                </dd>
+
             </dl>
 
             <h2 id="bbs">会議室・情報共有</h2>


### PR DESCRIPTION
以下の観点で修正しました。

・リリースお知らせ(リリース日は仮です)
・対象OSをWindows10のみに修正
・旧版が優先されていた記載をGitHubを主体に全体修正

とりあえずトップページのみ修正です。