### PR TITLE
v2.4.0 リリース用のドキュメント適用

### DIFF
--- a/help/HLP000001.html
+++ b/help/HLP000001.html
@@ -15,8 +15,8 @@
 -->
 <br>
 <center><hr width = "350px"></center>
-<center>サクラエディタ   Ver 2.4.0 (ベータ版v3)</center>
-<center>ヘルプファイル最終更新日 2019/12/21</center>
+<center>サクラエディタ   Ver 2.4.0</center>
+<center>ヘルプファイル最終更新日 2020/03/19</center>
 <center><a href="https://sakura-editor.github.io/" target=_blank>https://sakura-editor.github.io/</a></center>
 <center><hr width = "350px"></center>
 サクラエディタ(旧称:テキストエディタ)は、「たけ(竹パンダ)」さんのテキストエディタSAKURAの公開ソース(2000/02/21付)を元に不具合修正および機能拡張を行ったものです。<br>
@@ -112,7 +112,7 @@
 	■<a href="HLP_HISTORY.html">ヘルプファイル更新履歴</a><br>
 </div><br>
 <hr>
-Copyright (c)  2001-2015  Project Sakura-Editor.<br>
+Copyright (c)  2001-2020  Project SAKURA Editor.<br>
 Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.1 or any later version published by the Free Software Foundation.
 A copy of the license is included in the section entitled "GNU Free Documentation License".
 </BODY></HTML>


### PR DESCRIPTION
v2.4.0 リリース用のドキュメント適用

https://github.com/sakura-editor/sakura の `v2.4.0` タグの内容を適用したものです。

develop に適用後 master に適用しようと思います。