### PR TITLE
Google検索でヒットするダウンロードページの情報改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
         <li>2013-03-31　Ver.1.6.7.0 (ANSI版) 単体配布版をリリースしました。</li>
     </ul>
   
-  <h2>ダウンロード</h2>
+  <h2>最新版ダウンロード</h2>
   <dl>
     <dt>
       <a href="https://github.com/sakura-editor/sakura/releases">インストーラ、パッケージダウンロード</a>
@@ -87,21 +87,9 @@
 
             <h2>旧版ダウンロード</h2>
             <dl>
-                <dt><a href="./download.html" target="_blank">SourceForge Sakura Editor Files</a> [英語] (Old)</dt>
+                <dt><a href="./old_download.html" target="_blank">旧版ダウンロード</a></dt>
                 <dd>
                     GitHub移転前に公開されていたバージョンのダウンロード方法等記載。
-                </dd>
-
-                <dt>バイナリ＋関連ファイル簡単GET</dt>
-                <dd>
-                    <a href="http://sakura.qp.land.to/?Install%2FSakuraDown" target="_blank">SakuraDown</a>で、各種関連ファイルを自動的に取得できます。
-                </dd>
-    
-                <dt>64bit版バイナリ</dt>
-                <dd>
-                    旧版の64bit版バイナリはこちら
-                    <a href="http://sourceforge.net/p/sakura-editor/wiki/64bit/" target="_blank">Unicode</a> /
-                    <s><a href="." target="_blank">ANSI</a>版の公開サイトは閉鎖されました。</s>
                 </dd>
             </dl>
 

--- a/intro.html
+++ b/intro.html
@@ -24,7 +24,7 @@
       <!-- 見出しと検索ボックスを同じ行にいれるために form タグの中に入れています -->
       [<a href="/">▲HOME</a>]
       [機能紹介]
-      [<a href="/download.html">ダウンロード</a>]
+      [<a href="https://github.com/sakura-editor/sakura/releases">ダウンロード</a>]
       [<a href="https://github.com/sakura-editor/sakura/issues" target="_blank">GitHub Issues</a>]
       [<a href="https://osdn.net/projects/sakura-editor/forums/" target="_blank">OSDNフォーラム</a>]
 

--- a/old_download.html
+++ b/old_download.html
@@ -33,6 +33,10 @@
       </form>
   </p>
   <h1 class="title">サクラエディタ - ダウンロード</h1>
+  <p>
+    <span style="color:#f00; font-weight: bold; font-size: 1.5em;">※利便性・安定性の観点から、ファイルの運用場所を SourceForge から GitHub に移転しました(2018-05-28)。<br>
+                                                                   最新版は<a href="/">こちら</a></span>
+  </p>
   <h2>パッケージ概要</h2>
   <p>
     <ul>
@@ -53,10 +57,6 @@
     <a href="http://sakura.qp.land.to/?Install" target="_blank">こちら</a>をご覧ください． 関連ファイルをまとめてダウンロード＆インストールする
     <a href="http://sakura.qp.land.to/?Install%2FSakuraDown" target="_blank">Sakura Down
     </a>もあります．
-  </p>
-
-  <p>
-    <span style="color:#f00; font-weight: bold;">※利便性・安定性の観点から、ファイルの運用場所を SourceForge から GitHub に移転準備中です。移転が完了し次第、本ダウンロードページにおけるリンクも差し替えていきます。</span>
   </p>
 
   <h2>
@@ -141,6 +141,15 @@
   </h2>
   <p>ヘルプファイルの単体配布は
     <a href="http://sourceforge.net/projects/sakura-editor/" target="_blank">SourceForge</a>にて行っています。
+  </p>
+  <h2>
+    <a name="binary">64bit版バイナリ</a>
+  </h2>
+  <p>旧版の64bit版バイナリはこちら
+     <a href="http://sourceforge.net/p/sakura-editor/wiki/64bit/" target="_blank">Unicode</a> /
+     <s><a href="." target="_blank">ANSI</a>版の公開サイトは閉鎖されました。</s>
+  </p>
+  
 </body>
 
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,7 +7,7 @@
     <priority>1.0</priority>
 </url>
 <url>
-    <loc>https://sakura-editor.github.io/download.html</loc>
+    <loc>https://sakura-editor.github.io/old_download.html</loc>
     <lastmod>2018-05-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
Google検索でヒットするサクラエディタのダウンロードページの情報が古いものであるため、改善します。
変更は以下です。
・download.htmlをold_download.htmlにリネームし、古いバージョンの情報を置くようにした
→トップページに置いてあった旧版の64bit版もold_download.htmlに移動しています。

・intro.htmlの上部の「ダウンロード」リンクをgithubのreleasesに変更

・トップページの旧版ダウンロードリンクをold_download.htmlに変更


htmlファイル名がold_download.htmlになるので「old_」を解釈してくれればGoogle検索でヒットするのはトップページになるのではないかと思われます。
トップページであれば最新版のダウンロードリンクが記載してあるため、ユーザーは迷いなく最新版をダウンロードできるようになります。