### PR TITLE
sitemap.xml からダウンロードページ削除

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,12 +7,6 @@
     <priority>1.0</priority>
 </url>
 <url>
-    <loc>https://sakura-editor.github.io/download.html</loc>
-    <lastmod>2018-05-28</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
-</url>
-<url>
     <loc>https://sakura-editor.github.io/intro.html</loc>
     <lastmod>2018-05-28</lastmod>
     <changefreq>yearly</changefreq>


### PR DESCRIPTION
古いダウンロードページ(old_download.html)をsitemap.xmlから削除して検索サイトの検索インデックスから除外します。現状old_download.htmlは過去情報参照用にリポジトリ上からは削除しません。