### PR TITLE
Ver.2.4.1 のリリースを Web サイトでアナウンス

### DIFF
--- a/index.en.html
+++ b/index.en.html
@@ -36,6 +36,7 @@
 
   <h2>What's New</h2>
   <ul>
+    <li>2020-05-30 release Ver.2.4.1 (Executable and Installer)</li>
     <li>2020-04-19 release Ver.2.4.0 (Executable and Installer)</li>
     <li>2018-06-02 add link to <a href="https://github.com/sakura-editor/sakura/wiki" target="_blank">GitHub Wiki</a> </li>
     <li>2018-05-28 The project of "SAKURA" has migrated from SourceForge to <a href="https://github.com/sakura-editor/sakura" target="_blank">GitHub<a></li>

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
 
     <h2>What's New</h2>
     <ul>
+        <li>2020-05-30　Ver.2.4.1 をリリースしました。</li>
         <li>2020-04-19　Ver.2.4.0 をリリースしました。</li>
         <li>2018-06-02　<a href="https://github.com/sakura-editor/sakura/wiki" target="_blank">GitHub Wiki</a> へのリンクを追加</li>
         <li>2018-05-28　プロジェクトを SourceForge から <a href="https://github.com/sakura-editor/sakura" target="_blank">GitHub</a> に移転しました。</li>


### PR DESCRIPTION
Ver.2.4.1 のリリースを Web サイトでアナウンス

※ https://github.com/sakura-editor/sakura-editor.github.io/pull/66 は Web サイトで公開するヘルプの更新です。