### PR TITLE
osdn.net のリンクを削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,6 @@
         [<a href="/help/">ヘルプ</a>]
         [<a href="https://github.com/sakura-editor/sakura/releases">ダウンロード</a>]
         [<a href="https://github.com/sakura-editor/sakura/issues" target="_blank">GitHub Issues</a>]
-        [<a href="https://ja.osdn.net/projects/sakura-editor/forums/34071/" target="_blank">一般話題（質疑・要望等）</a>]
-        [<a href="https://ja.osdn.net/projects/sakura-editor/forums/34094/" target="_blank">マクロ掲示板</a>]
         [<a href="index.en.html" target="_blank">English</a>]
 
         <!-- Google の検索ボックス -->
@@ -129,9 +127,6 @@
             <h2 id="bbs">会議室・情報共有</h2>
             <ul>
                 <li><b><a href="https://github.com/sakura-editor/sakura/issues" target="_blank">GitHub Issues</a></b> … 要望・バグ報告等はこちらからご連絡ください (GitHub<a href="https://www.google.co.jp/search?q=github+%E3%82%A2%E3%82%AB%E3%82%A6%E3%83%B3%E3%83%88+%E4%BD%9C%E6%88%90+%E6%96%B9%E6%B3%95" target="_blank">ユーザー登録</a>が必要です。）</li>
-                <li><a href="https://ja.osdn.net/projects/sakura-editor/forums/34071/" target="_blank">一般話題（質疑・要望等）</a>(OSDN) … GitHub投稿が難しい方はこちらをご利用ください、匿名投稿可</li>
-                <li><a href="https://ja.osdn.net/projects/sakura-editor/forums/34094/" target="_blank">マクロ掲示板</a>(OSDN) … マクロの質問や自作マクロ、匿名投稿可</li>
-                <li><a href="https://ja.osdn.net/projects/sakura-editor/ticket/" target="_blank">アップローダー</a>(OSDN) … 要OSDNログイン。アップされたファイルは開発メンバーのチェックがなされていませんのでご利用は自己責任で。</li>
                 <li><a href="https://discord.gg/MTWB4ut" target="_blank">Discord</a> … 一般話題・開発話題 混在チャット</li>
                 <li><a href="http://sakura.qp.land.to" target="_blank">land.to Wiki</a> … FAQ, Tips, Document, etc.</li>
                 <li><a href="https://ux.getuploader.com/sakura_editor/" target="_blank">旧アップローダー</a> … uploader.jp利用。アップされたファイルは開発メンバーのチェックがなされていませんのでご利用は自己責任で。</li>

--- a/intro.html
+++ b/intro.html
@@ -26,7 +26,6 @@
       [機能紹介]
       [<a href="https://github.com/sakura-editor/sakura/releases">ダウンロード</a>]
       [<a href="https://github.com/sakura-editor/sakura/issues" target="_blank">GitHub Issues</a>]
-      [<a href="https://osdn.net/projects/sakura-editor/forums/" target="_blank">OSDNフォーラム</a>]
 
       <!-- Google の検索ボックス -->
       <input type="hidden" name="ie" value="UTF-8" />

--- a/old_download.html
+++ b/old_download.html
@@ -23,7 +23,6 @@
         [<a href="/intro.html">機能紹介</a>]
         [ダウンロード]
         [<a href="https://github.com/sakura-editor/sakura/issues" target="_blank">GitHub Issues</a>]
-        [<a href="https://osdn.net/projects/sakura-editor/forums/" target="_blank">OSDNフォーラム</a>]
 
         <!-- Google の検索ボックス -->
         <input type="hidden" name="ie" value="UTF-8" />


### PR DESCRIPTION
OSDN サービス終了のため、osdn.net のリンクを削除しました。
https://ja.wikipedia.org/wiki/OSDN
